### PR TITLE
Fixes RCTContacts.xcodeproj location in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ run `npm install react-native-contacts`
 
 ### iOS
 1. In XCode, in the project navigator, right click `Libraries` ➜ `Add Files to [your project's name]`
-2. add `./node_modules/react-native-contacts/RCTContacts.xcodeproj`
+2. add `./node_modules/react-native-contacts/ios/RCTContacts.xcodeproj`
 3. In the XCode project navigator, select your project, select the `Build Phases` tab and in the `Link Binary With Libraries` section add **libRCTContacts.a**
 
 ### Android


### PR DESCRIPTION
#### What's this PR do?

Changes `./node_modules/react-native-contacts/RCTContacts.xcodeproj` to `./node_modules/react-native-contacts/ios/RCTContacts.xcodeproj` in the ios getting started docs.
#### Any background context you want to provide?

The path specified in docs currently is invalid.
